### PR TITLE
Changes to Dockerfile to allow builds on arm32v7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN case $(uname -m) in 				\
 	armv7l)						\
 		ARCH=arm				\
 	;;						\
+	aarch64)					\
+		ARCH=arm64				\
+	;;						\
 	amd64|x86_64)					\
 		ARCH=x86_64				\
 	;;						\

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ RUN case $(uname -m) in 				\
 		ARCH=unknown				\
 	;;						\
 	esac;						\
-	echo "Installing dnscrypt-proxy for ${ARCH}";	\
-	curl --silent -L https://github.com/jedisct1/dnscrypt-proxy/releases/download/2.0.25/dnscrypt-proxy-linux_${ARCH}-2.0.25.tar.gz > dnscrypt-proxy-linux_${ARCH}.tar.gz && \
+	VER=2.0.25;					\
+	echo "Installing dnscrypt-proxy-${VER} for ${ARCH}";	\
+	curl --silent -L https://github.com/jedisct1/dnscrypt-proxy/releases/download/${VER}/dnscrypt-proxy-linux_${ARCH}-${VER}.tar.gz > dnscrypt-proxy-linux_${ARCH}.tar.gz && \
 	tar -xzf dnscrypt-proxy-linux_${ARCH}.tar.gz && \
 	mv linux-${ARCH}/dnscrypt-proxy $GOPATH/bin/dnscrypt-proxy && \
 	rm -rf dnscrypt-proxy-linux_${ARCH}.tar.gz linux-${ARCH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN case $(uname -m) in 				\
 		ARCH=unknown				\
 	;;						\
 	esac;						\
-	VER=2.0.25;					\
+	VER=2.0.26;					\
 	echo "Installing dnscrypt-proxy-${VER} for ${ARCH}";	\
 	curl --silent -L https://github.com/jedisct1/dnscrypt-proxy/releases/download/${VER}/dnscrypt-proxy-linux_${ARCH}-${VER}.tar.gz > dnscrypt-proxy-linux_${ARCH}.tar.gz && \
 	tar -xzf dnscrypt-proxy-linux_${ARCH}.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,25 @@ RUN apk add --update bind-tools curl git && \
 ADD dnscrypt-proxy.toml /etc/dnscrypt-proxy/dnscrypt-proxy.toml
 ADD test.sh /etc/dnscrypt-proxy/test.sh
 
-RUN curl --silent -L https://github.com/jedisct1/dnscrypt-proxy/releases/download/2.0.25/dnscrypt-proxy-linux_arm-2.0.25.tar.gz > dnscrypt-proxy-linux_arm.tar.gz && \
-	tar -xzf dnscrypt-proxy-linux_arm.tar.gz && \
-	mv linux-arm/dnscrypt-proxy $GOPATH/bin/dnscrypt-proxy && \
-	rm -rf dnscrypt-proxy-linux_arm.tar.gz linux-arm
+ARG ARCH
+
+RUN case $(uname -m) in 				\
+	armv71)						\
+		ARCH=arm				\
+	;;						\
+	amd64)						\
+		ARCH=x86_64				\
+	;;						\
+	*)						\
+		echo "Unhandled arch!  Please report!"	\
+		ARCH=unknown				\
+	;;						\
+	esac
+
+RUN curl --silent -L https://github.com/jedisct1/dnscrypt-proxy/releases/download/2.0.25/dnscrypt-proxy-linux_${ARCH}-2.0.25.tar.gz > dnscrypt-proxy-linux_${ARCH}.tar.gz && \
+	tar -xzf dnscrypt-proxy-linux_${ARCH}.tar.gz && \
+	mv linux-${ARCH}/dnscrypt-proxy $GOPATH/bin/dnscrypt-proxy && \
+	rm -rf dnscrypt-proxy-linux_${ARCH}.tar.gz linux-${ARCH}
 
 ENTRYPOINT ["/go/bin/dnscrypt-proxy", "-config", "/etc/dnscrypt-proxy/dnscrypt-proxy.toml"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --update bind-tools curl git && \
 ADD dnscrypt-proxy.toml /etc/dnscrypt-proxy/dnscrypt-proxy.toml
 ADD test.sh /etc/dnscrypt-proxy/test.sh
 
-RUN curl --silent -L https://github.com/jedisct1/dnscrypt-proxy/releases/download/2.0.25/dnscrypt-proxy-linux_arm-2.0.25.tar.gz > dnscrypt-proxy-linux_x86_64.tar.gz && \
+RUN curl --silent -L https://github.com/jedisct1/dnscrypt-proxy/releases/download/2.0.25/dnscrypt-proxy-linux_arm-2.0.25.tar.gz > dnscrypt-proxy-linux_arm.tar.gz && \
 	tar -xzf dnscrypt-proxy-linux_arm.tar.gz && \
 	mv linux-arm/dnscrypt-proxy $GOPATH/bin/dnscrypt-proxy && \
 	rm -rf dnscrypt-proxy-linux_arm.tar.gz linux-arm

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ RUN apk add --update bind-tools curl git && \
 ADD dnscrypt-proxy.toml /etc/dnscrypt-proxy/dnscrypt-proxy.toml
 ADD test.sh /etc/dnscrypt-proxy/test.sh
 
-RUN curl --silent -L https://github.com/jedisct1/dnscrypt-proxy/releases/download/2.0.25/dnscrypt-proxy-linux_x86_64-2.0.25.tar.gz > dnscrypt-proxy-linux_x86_64.tar.gz && \
-	tar -xzf dnscrypt-proxy-linux_x86_64.tar.gz && \
-	mv linux-x86_64/dnscrypt-proxy $GOPATH/bin/dnscrypt-proxy && \
-	rm -rf dnscrypt-proxy-linux_x86_64.tar.gz linux-x86_64
+RUN curl --silent -L https://github.com/jedisct1/dnscrypt-proxy/releases/download/2.0.25/dnscrypt-proxy-linux_arm-2.0.25.tar.gz > dnscrypt-proxy-linux_x86_64.tar.gz && \
+	tar -xzf dnscrypt-proxy-linux_arm.tar.gz && \
+	mv linux-arm/dnscrypt-proxy $GOPATH/bin/dnscrypt-proxy && \
+	rm -rf dnscrypt-proxy-linux_arm.tar.gz linux-arm
 
 ENTRYPOINT ["/go/bin/dnscrypt-proxy", "-config", "/etc/dnscrypt-proxy/dnscrypt-proxy.toml"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN case $(uname -m) in 				\
 	armv7l)						\
 		ARCH=arm				\
 	;;						\
-	aarch64)					\
+	arm64|aarch64)					\
 		ARCH=arm64				\
 	;;						\
 	amd64|x86_64)					\
@@ -22,7 +22,7 @@ RUN case $(uname -m) in 				\
 		ARCH=unknown				\
 	;;						\
 	esac;						\
-	VER=2.0.26;					\
+	VER=2.0.27;					\
 	echo "Installing dnscrypt-proxy-${VER} for ${ARCH}";	\
 	curl --silent -L https://github.com/jedisct1/dnscrypt-proxy/releases/download/${VER}/dnscrypt-proxy-linux_${ARCH}-${VER}.tar.gz > dnscrypt-proxy-linux_${ARCH}.tar.gz && \
 	tar -xzf dnscrypt-proxy-linux_${ARCH}.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,22 +7,20 @@ RUN apk add --update bind-tools curl git && \
 ADD dnscrypt-proxy.toml /etc/dnscrypt-proxy/dnscrypt-proxy.toml
 ADD test.sh /etc/dnscrypt-proxy/test.sh
 
-ARG ARCH
-
 RUN case $(uname -m) in 				\
-	armv71)						\
+	armv7l)						\
 		ARCH=arm				\
 	;;						\
-	amd64)						\
+	amd64|x86_64)					\
 		ARCH=x86_64				\
 	;;						\
 	*)						\
-		echo "Unhandled arch!  Please report!"	\
+		echo "Unhandled arch $(uname -m)!  Please report!" \
 		ARCH=unknown				\
 	;;						\
-	esac
-
-RUN curl --silent -L https://github.com/jedisct1/dnscrypt-proxy/releases/download/2.0.25/dnscrypt-proxy-linux_${ARCH}-2.0.25.tar.gz > dnscrypt-proxy-linux_${ARCH}.tar.gz && \
+	esac;						\
+	echo "Installing dnscrypt-proxy for ${ARCH}";	\
+	curl --silent -L https://github.com/jedisct1/dnscrypt-proxy/releases/download/2.0.25/dnscrypt-proxy-linux_${ARCH}-2.0.25.tar.gz > dnscrypt-proxy-linux_${ARCH}.tar.gz && \
 	tar -xzf dnscrypt-proxy-linux_${ARCH}.tar.gz && \
 	mv linux-${ARCH}/dnscrypt-proxy $GOPATH/bin/dnscrypt-proxy && \
 	rm -rf dnscrypt-proxy-linux_${ARCH}.tar.gz linux-${ARCH}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # DNSCrypt-Proxy
 
-Forked from mattbodholdt/dnscrypt-proxy to build on arm32v7 (Raspberry Pi 3).
-
 A DNS server container which consumes Cloudflare's DNS over HTTPS resolution service (https://developers.cloudflare.com/1.1.1.1/dns-over-https/, https://1.1.1.1) by utilizing DNSCrypt Proxy (https://github.com/jedisct1/dnscrypt-proxy, https://dnscrypt.info/).
 
 In this config, tcp and udp port 53 must be free on the host:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DNSCrypt-Proxy
 
+Forked from mattbodholdt/dnscrypt-proxy to build on arm32v7 (Raspberry Pi 3).
+
 A DNS server container which consumes Cloudflare's DNS over HTTPS resolution service (https://developers.cloudflare.com/1.1.1.1/dns-over-https/, https://1.1.1.1) by utilizing DNSCrypt Proxy (https://github.com/jedisct1/dnscrypt-proxy, https://dnscrypt.info/).
 
 In this config, tcp and udp port 53 must be free on the host:


### PR DESCRIPTION
I like this project, but my docker/k8s cluster is all arm32v7.  Thus I've modified the Dockerfile to do build arch detection to know which dnscrypt-proxy file to download.  As a case statement, it can be easily extended to handle additional architectures (I do not have test gear for alternate architectures, however).