### PR TITLE
Replace deprecated fallback_resolver by bootstrap_resolvers

### DIFF
--- a/dnscrypt-proxy.toml
+++ b/dnscrypt-proxy.toml
@@ -184,23 +184,37 @@ cert_refresh_delay = 240
 # tls_cipher_suite = [52392, 49199]
 
 
-## Fallback resolvers
-## These are normal, non-encrypted DNS resolvers, that will be only used
-## for one-shot queries when retrieving the initial resolvers list, and
-## only if the system DNS configuration doesn't work.
-## No user application queries will ever be leaked through these resolvers,
-## and they will not be used after IP addresses of resolvers URLs have been found.
-## They will never be used if lists have already been cached, and if stamps
-## don't include host names without IP addresses.
-## They will not be used if the configured system DNS works.
-## Resolvers supporting DNSSEC are recommended.
+## Bootstrap resolvers
 ##
-## People in China may need to use 114.114.114.114:53 here.
-## Other popular options include 8.8.8.8 and 1.1.1.1.
+## These are normal, non-encrypted DNS resolvers, that will be only used
+## for one-shot queries when retrieving the initial resolvers list and the
+## the system DNS configuration doesn't work.
+##
+## No user queries will ever be leaked through these resolvers, and they will
+## not be used after IP addresses of DoH resolvers have been found (if you are
+## using DoH).
+##
+## They will never be used if lists have already been cached, and if the stamps
+## of the configured servers already include IP addresses (which is the case for
+## most of DoH servers, and for all DNSCrypt servers and relays).
+##
+## They will not be used if the configured system DNS works, or after the
+## proxy already has at least one usable secure resolver.
+##
+## Resolvers supporting DNSSEC are recommended, and, if you are using
+## DoH, bootstrap resolvers should ideally be operated by a different entity
+## than the DoH servers you will be using, especially if you have IPv6 enabled.
+##
+## People in China may want to use 114.114.114.114:53 here.
+## Other popular options include 8.8.8.8, 9.9.9.9 and 1.1.1.1.
 ##
 ## If more than one resolver is specified, they will be tried in sequence.
+##
+## TL;DR: put valid standard resolver addresses here. Your actual queries will
+## not be sent there. If you're using DNSCrypt or Anonymized DNS and your
+## lists are up to date, these resolvers will not even be used.
 
-fallback_resolver = '1.1.1.1:53'
+bootstrap_resolvers = ['1.1.1.1:53']
 
 
 ## Always use the fallback resolver before the system DNS settings.


### PR DESCRIPTION
fallback_resolver was deprecated and replaced by bootstrap_resolvers: https://github.com/DNSCrypt/dnscrypt-proxy/commit/33ed882efea57cc7daf7ee93deeb991b72064fa8

The current image fails starting:
```
[2021-08-13 06:32:46] [NOTICE] dnscrypt-proxy 2.0.46-beta2
[2021-08-13 06:32:46] [FATAL] Unsupported key in configuration file: [fallback_resolver]
```